### PR TITLE
Run Quartz build through node

### DIFF
--- a/tools/site/src/main.rs
+++ b/tools/site/src/main.rs
@@ -69,11 +69,11 @@ impl Site {
 
         self.pnpm_install(&self.root, InstallMode::Locked)?;
 
-        let mut args = os_args(&["exec", "quartz", "build"]);
+        let mut args = os_args(&["--no-deprecation", "quartz/bootstrap-cli.mjs", "build"]);
         if mode == Mode::Dev {
             args.push("--serve".into());
         }
-        self.run(&self.root, "pnpm", &args)?;
+        self.run(&self.root, "node", &args)?;
 
         let public = self.root.join("public");
         let elapsed = started.elapsed().as_secs().to_string();


### PR DESCRIPTION
Fixes the Deploy workflow failure after the dependency updates. The site runner used pnpm exec quartz build, but pnpm does not expose this package own quartz bin that way in CI, so the workflow failed with Command quartz not found. This calls the checked-in Quartz CLI through Node directly instead. Verification: corepack pnpm install --frozen-lockfile; node --no-deprecation ./quartz/bootstrap-cli.mjs build.