### PR TITLE
Update wasm random dependencies

### DIFF
--- a/wasm/wasm/Cargo.toml
+++ b/wasm/wasm/Cargo.toml
@@ -21,7 +21,7 @@ music21-rs = { git = "https://github.com/float3/music21-rs.git" }
 # [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2.100" }
 console_error_panic_hook = { version = "0.1.7", optional = true }
-mini-alloc = { version = "0.9.0", optional = true }
+mini-alloc = { version = "1.0.0", optional = true }
 glsl2hlsl = { path = "../glsl2hlsl" }
 adventofcode = { path = "../adventofcode/" }
 textprocessing = { path = "../textprocessing/" }
@@ -31,12 +31,17 @@ web-sys = { version = "0.3.77", features = [
     "CanvasRenderingContext2d",
     "HtmlCanvasElement",
 ] }
-getrandom = { version = "0.3.3", features = ["wasm_js"] }
+getrandom = { version = "0.4.0", features = ["wasm_js"] }
 krabby = { git = "https://github.com/float3/krabby/", features = [
     "debug-embed",
     "html",
 ] }
 unicode-width = "0.2.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# Transitive crates still pull getrandom 0.3, and the wasm build sets
+# getrandom_backend="wasm_js" globally.
+getrandom_03 = { package = "getrandom", version = "0.3.4", features = ["wasm_js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"


### PR DESCRIPTION
Replaces #96 with the same mini-alloc 1.0/getrandom 0.4 update plus a wasm-target getrandom 0.3 feature shim. The shim is needed because transitive crates still resolve getrandom 0.3 while this repo builds wasm with getrandom_backend=wasm_js. Verification: cargo check --manifest-path wasm/wasm/Cargo.toml --target wasm32-unknown-unknown with RUSTFLAGS getrandom_backend=wasm_js; wasm-pack build --target bundler --release --features console_error_panic_hook with the same RUSTFLAGS.